### PR TITLE
bugfix-program-scroll

### DIFF
--- a/src/sass/_program.scss
+++ b/src/sass/_program.scss
@@ -195,9 +195,9 @@
     background-size: contain;
     background-repeat: no-repeat;
     height: 137px;
-    width: 176px;
+    width: 120px;
     bottom: -3.5%;
-    right: -17%;
+    right: -4%;
     z-index: 2;
     @media (min-device-pixel-ratio: 2), (min-resolution: 192dpi), (min-resolution: 2dppx) {
       background-image: url('../images/program-mobile@2x.png');

--- a/src/sass/_program.scss
+++ b/src/sass/_program.scss
@@ -197,7 +197,7 @@
     height: 137px;
     width: 120px;
     bottom: -3.5%;
-    right: -4%;
+    right: -19px;
     z-index: 2;
     @media (min-device-pixel-ratio: 2), (min-resolution: 192dpi), (min-resolution: 2dppx) {
       background-image: url('../images/program-mobile@2x.png');


### PR DESCRIPTION
Горизонтальный скролл появлялся из-за размера картинки в мобильном варианте. По макету он указан больше чем в реальности.